### PR TITLE
Support Markdown-rendered footer, update defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,90 @@
-Math integration with GitBook
+Page Footer EX for Gitbook
 ==============
 
+> A minimalist footer for Gitbook.
+
 ### 插件风格
+
 极简
-![image](https://raw.githubusercontent.com/zq99299/gitbook-plugin-page-footer-ex/master/doc/images/gitbook-plugin-page-footer-ex-demo.jpg)
 
-### 本插件的功能：
-定制页脚
+![Demo of footer](https://raw.githubusercontent.com/zq99299/gitbook-plugin-page-footer-ex/master/doc/images/gitbook-plugin-page-footer-ex-demo.jpg)
 
-1. 版权信息
-2. 文档更新时间
+### 本插件的功能 / Features
 
-### 致敬
-本插件修改至
+定制页脚 / Customization
+
+1. 版权信息 / Copyright Information
+2. 文档更新时间 / Document update time
+
+### 致敬 / Credit
+
+本插件修改至 / forked from
 
 1. https://github.com/zhj3618/gitbook-plugin-tbfed-pagefooter
+
 修改原因：原插件的信息不能完全自定义。
 
-### How to use it?
+### Usage
 
-Add it to your `book.json` configuration:
+Add it to your `book.json`:
 
-```
+```json
 {
-  "plugins": [
-       "page-footer-ex"
-  ]
+    "plugins": [
+        "page-footer-ex"
+    ],
+    "pluginsConfig": {
+        "page-footer-ex": {
+            "copyright": "By <em>author name</em>",
+            "markdown": false,
+            "update_label": "<i>updated</i>",
+            "update_format": "YYYY-MM-DD HH:mm:ss",
+        }
+    }
 }
 ```
 
-Install your plugins using:
+### Configuration Properties
 
-```
-$ gitbook install ./
-``` 
-
-### Configuration
-
-You can force the use of svg pre-processed by adding to your book.json:
-
-```
+```json
 {
- "pluginsConfig": {	   
-		"page-footer-ex":{
-			"copyright":"mrcode",
-			"update_label":"update",
-			"update_format":"YYYY-MM-DD HH:mm:ss",
-		}	   
-  }	
+      "copyright": {
+        "type": "string",
+        "default": "© All Rights Reserved",
+        "title": "你的版权信息",
+        "description": "Copyright text"
+      },
+      "markdown": {
+        "type": "boolean",
+        "default": false,
+        "title": "",
+        "description": "Default false for plain text/HTML, true to parse copyright and update_label as Markdown"
+      },
+      "update_label": {
+        "type": "string",
+        "default": "updated",
+        "title": "文档更新时间标签内容",
+        "description": "Date label"
+      },
+      "update_format": {
+        "type": "string",
+        "default": "YYYY-MM-DD HH:mm:ss",
+        "title": "时间格式",
+        "description": "Moment.js date format"
+      }
 }
 ```
-- copyright ： 你的版权信息，可以是html
-- update_label ： 文档更新时间标签，可以是html
-- update_format ： 时间格式
- 
-### or Install locally
-
-```
-$ npm install gitbook-plugin-page-footer-ex --save
-```
-
->open npm : https://www.npmjs.com/package/gitbook-plugin-page-footer-ex
 
 ### Update record
 
 #### v0.0.4 2017-02-17
+
 1. 页脚在pdf中显示不美观，在版权信息和更新时间信息中间增加10个空格。
 只有在插件css不被调用的时候，这个空格会影响格式。达到分离的效果。在正常网站上观看不会出现这种问题
 2. 修改默认配置参数
 
 #### 2017-02-07
+
 完成开发。
 
 

--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -1,43 +1,34 @@
-
-/**
- * 处理默认参数
- * @param defaultOption
- * @param configOption
- */
-function handlerOption(defaultOption, configOption) {
-    if (configOption) {
-        for (var item in defaultOption) {
-            if (item in configOption) {
-                defaultOption[item] = configOption[item];
-            }
-        }
-    }
-}
-
-function start(bookIns, page) {
-    const defaultOption = {
-        copyright: 'for GitBook.',
-        update_label: 'update : ',
-        update_format: 'YYYY-MM-DD HH:mm:ss'
-    }
+module.exports = function(book, page) {
     /**
-     * [configOption: config option]
+     * [config: config option]
      * @type {Object}
      */
-    var configOption = bookIns.config.get('pluginsConfig')['page-footer-ex'];
-    // 处理配置参数
-    handlerOption(defaultOption, configOption);
+    var config = book.config.get('pluginsConfig')['page-footer-ex'];
 
-    var _copy = '<span class="page-footer-ex-copyright">' + defaultOption.copyright + '</span>'
-    var wrap = ' \n\n' +
-        '<footer class="page-footer-ex"> ' +
-                _copy +
-            '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' +
-            '<span class="page-footer-ex-footer-update">' + defaultOption.update_label +
-                '\n{{ file.mtime | dateFormat("' + defaultOption.update_format + '") }}\n' +
-            '</span>' +
-        '</footer>'
-    page.content = page.content + wrap;
+    var wrapIfMarkdown = function(input) {
+        if (!config.markdown) {
+            return input;
+        } else {
+            return book.renderInline('markdown', input);
+        }
+    }
+    // Gitbook Markdown rendering is asynchronous.
+    return Promise.all([wrapIfMarkdown(config.copyright), wrapIfMarkdown(config.update_label)])
+        .then(function(labels) {
+            var copyright = labels[0];
+            var updateLabel = labels[1];
+            page.content += [
+                '<footer class="page-footer-ex">',
+                    '<div class="page-footer-ex-copyright">',
+                        copyright,
+                    '</div>',
+                    '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+                    '<div class="page-footer-ex-footer-update">',
+                        updateLabel,
+                        '{{ file.mtime | dateFormat("' + config.update_format + '") }}',
+                    '</div>',
+                '</footer>'
+            ].join('\n');
+            return page;
+        });
 }
-
-module.exports = start;

--- a/assets/style/plugin.css
+++ b/assets/style/plugin.css
@@ -6,10 +6,14 @@
     font-size: 12px;
     color: #808080;
 }
+.page-footer-ex-copyright {
+    display: inline-block;
+}
 .page-footer-ex a {
-    color: #808080!important;
-    text-decoration: underline!important;
+    color: #808080 !important;
+    text-decoration: underline !important;
 }
 .page-footer-ex-footer-update {
     float: right;
+    display: inline-block;
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _start = require('./assets/lib/plugin');
+var footer = require('./assets/lib/plugin');
 var moment = require('moment');
 
 module.exports = {
@@ -8,14 +8,12 @@ module.exports = {
     },
     hooks: {
         'page:before': function (page) {
-            var bookIns = this;
-            _start(bookIns, page);
-            return page;
+            return footer(this, page);
         }
     },
     filters: {
         dateFormat: function (d, format) {
-            return moment(d).format(format)
+            return moment(d).format(format);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "keywords": [
     "gitbook",
     "plugin",
-	"page-footer-ex",
-	"footer",
-	"ex"
+    "page-footer-ex",
+    "footer",
+    "ex"
   ],
   "author": "zhuqiang",
   "license": "GPL-3.0",
@@ -30,22 +30,31 @@
     "gitbook": ">=3.0.0"
   },
   "gitbook": {
-        "properties": {
-            "copyright": {
-                "type": "string",
-                "default": "for GitBook",
-                "title": "你的版权信息"
-            },
-			"update_label": {
-                "type": "string",
-                "default": "update",
-                "title": "文档更新时间标签内容"
-            },
-			"update_format": {
-                "type": "string",
-                "default": "YYYY-MM-DD HH:mm:ss",
-                "title": "时间格式"
-            }
-        }
+    "properties": {
+      "copyright": {
+        "type": "string",
+        "default": "© All Rights Reserved",
+        "title": "你的版权信息",
+        "description": "The left-aligned text in the footer."
+      },
+      "markdown": {
+        "type": "boolean",
+        "default": false,
+        "title": "",
+        "description": "True if copyright and update_label are in Markdown, false if plain text or HTML."
+      },
+      "update_label": {
+        "type": "string",
+        "default": "updated",
+        "title": "文档更新时间标签内容",
+        "description": "Text before date."
+      },
+      "update_format": {
+        "type": "string",
+        "default": "YYYY-MM-DD HH:mm:ss",
+        "title": "时间格式",
+        "description": "Moment.js date format."
+      }
     }
+  }
 }


### PR DESCRIPTION
This PR:

- Adds Markdown support, fix #2
- Updates the readme
  - Bilingual
  - Cleaned up to be shorter and more concise
- Updates default values
  - for Gitbook → © All Rights Reserved
  - update → updated
- Clean up code
  - Defaults do not need to be handled manually, Gitbook handles them already
  - Hook is now async since gitbook's Markdown renderer is async

Please let me know if you have any questions or improvements!