### PR TITLE
Keep generated HTML to one line

### DIFF
--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -9,22 +9,26 @@ module.exports = function(book, page) {
         if (!config.markdown) {
             return input;
         } else {
-            return '{% markdown %}\n' + input + '\n{% endmarkdown %}';
+            return book.renderInline('markdown', input);
         }
     }
-    var copyright = wrapIfMarkdown(config.copyright)
-    var updateLabel = wrapIfMarkdown(config.update_label)
-    page.content += [
-        '<footer class="page-footer-ex">',
-            '<div class="page-footer-ex-copyright">',
-                copyright,
-            '</div>',
-            '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-            '<div class="page-footer-ex-footer-update">',
-                updateLabel,
-                '{{ file.mtime | dateFormat("' + config.update_format + '") }}',
-            '</div>',
-        '</footer>'
-    ].join('\n');
-    return page;
+    // Gitbook Markdown rendering is asynchronous.
+    return Promise.all([wrapIfMarkdown(config.copyright), wrapIfMarkdown(config.update_label)])
+        .then(function(labels) {
+            var copyright = labels[0];
+            var updateLabel = labels[1];
+            page.content += [
+                '<footer class="page-footer-ex">',
+                    '<div class="page-footer-ex-copyright">',
+                        copyright,
+                    '</div>',
+                    '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+                    '<div class="page-footer-ex-footer-update">',
+                        updateLabel,
+                        '{{ file.mtime | dateFormat("' + config.update_format + '") }}',
+                    '</div>',
+                '</footer>'
+            ].join('\n');
+            return page;
+        });
 }

--- a/assets/lib/plugin.js
+++ b/assets/lib/plugin.js
@@ -28,7 +28,7 @@ module.exports = function(book, page) {
                         '{{ file.mtime | dateFormat("' + config.update_format + '") }}',
                     '</div>',
                 '</footer>'
-            ].join('\n');
+            ].join(' ');
             return page;
         });
 }


### PR DESCRIPTION
The HTML we generated was being parsed as Markdown which caused formatting issues on some pages.

Revert to the async method, and keep all the generated HTML to one line so that it is processed properly.